### PR TITLE
安裝 wkhtmltopdf binary 到 heroku ~~ 不能走 apt QQ

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -14,13 +14,18 @@ BIN_PATH="$BUILD_DIR/bin"
 TMP_PATH="$BUILD_DIR/tmp"
 mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
 
+OS_VERSIONCODE=$(cat /etc/os-release | grep VERSION_CODENAME)
 
-if [ "$STACK" == "cedar-14" ]; then
-  UBUNTU_VERSION="trusty"
-elif [ "$STACK" == "heroku-16" ]; then
-  UBUNTU_VERSION="xenial"
+if [[ "$OS_VERSIONCODE" == *"VERSION_CODENAME=focal"* ]]; then
+    # focal is codename of ubuntu 20
+    UBUNTU_VERSION="focal"
+elif [[ "$OS_VERSIONCODE" == *"VERSION_CODENAME=xenial"* ]]; then
+    # install wkhtmltopdf for ubuntu 16
+    UBUNTU_VERSION="xenial"
 else
-  UBUNTU_VERSION="bionic"
+    # default version is for ubuntu 16
+    echo -e "${YELLOW}WARNING: ${OS_VERSIONCODE} not supported, install default wkhtmltopdf deb for Ubuntu 16${WHITE}"
+    UBUNTU_VERSION="xenial"
 fi
 
 WKHTMLTOPDF_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.${UBUNTU_VERSION}_amd64.deb"
@@ -32,33 +37,34 @@ BIN_DIR=$(cd $(dirname $0); pwd)
 FONTS_DIR=$(cd "$BIN_DIR/../fonts"; pwd)
 
 if [ -f $WKHTMLTOPDF_PKG ]; then
-  echo "-----> Using wkhtmltopdf Debian package from cache"
+  echo -e "${GREEN}-----> Using wkhtmltopdf Debian package from cache${WHITE}"
 else
-  echo "-----> Downloading wkhtmltopdf Debian package from ${WKHTMLTOPDF_URL}"
+  echo -e "${GREEN}-----> Downloading wkhtmltopdf Debian package from ${WKHTMLTOPDF_URL} ${WHITE}"
   curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
 fi
 
-echo "-----> Unpacking Debian package"
+echo -e "${GREEN}-----> Unpacking Debian package${WHITE}"
 dpkg -x $WKHTMLTOPDF_PKG $WKHTMLTOPDF_PATH
 
-echo "-----> Setting permissions"
+echo -e "${GREEN}-----> Setting permissions"
 chmod +x $WKHTMLTOPDF_BINARIES/*
 
-echo "-----> Moving binaries to the right place"
+echo -e "${GREEN}-----> Moving binaries to the right place${WHITE}"
 mv $WKHTMLTOPDF_BINARIES/* $BIN_PATH/
 
-echo "-----> Removing wkhtmltoimage binary"
+echo -e "${GREEN}-----> Removing wkhtmltoimage binary${WHITE}"
 rm -rf "$BIN_PATH/wkhtmltoimage"
 
+echo -e "${GREEN}-----> Setting Continer Start script in $BUILD_DIR/.profile.d${WHITE}"
 mkdir -p "$BUILD_DIR"/.profile.d
 cat <<EOF >"$BUILD_DIR"/.profile.d/wkhtmltopdf.sh
 export PATH="/app/bin:\$PATH"
 EOF
 
-echo "-----> Cleaning up"
+echo -e "${GREEN}-----> Cleaning up${WHITE}"
 rm -rf $WKHTMLTOPDF_PATH
 
-echo "-----> Installing fonts"
+echo -e "${GREEN}-----> Installing fonts${WHITE}"
 mkdir -p $1/.fonts
 ls $FONTS_DIR
 cp $FONTS_DIR/* $1/.fonts/

--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 
 BIN_PATH="$BUILD_DIR/.wkhtmltopdf/bin"
-LIB_PATH="$BUILD_DIR/.wkhtmltopdf/lib"
+# LIB_PATH="$BUILD_DIR/.wkhtmltopdf/lib"
 TMP_PATH="$BUILD_DIR/tmp"
 mkdir -p $CACHE_DIR $BIN_PATH $LIB_PATH $TMP_PATH
 
@@ -48,24 +48,24 @@ FONTS_DIR=$(cd "$BIN_DIR/../fonts"; pwd)
 echo -e "${GREEN}-----> Downloading wkhtmltopdf Debian package from ${WKHTMLTOPDF_URL} ${WHITE}"
 curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
 
-LIBPNG12_URL='https://launchpad.net/~ubuntu-security/+archive/ubuntu/ppa/+build/15108504/+files/libpng12-0_1.2.54-1ubuntu1.1_amd64.deb'
-LIBPNG12_PKG="$CACHE_DIR/libpng12.deb"
-LIBPNG12_PATH="$TMP_PATH/libpng12"
-LIBPNG12_BINARY="$LIBPNG12_PATH/usr/lib/x86_64-linux-gnu"
+# LIBPNG12_URL='https://launchpad.net/~ubuntu-security/+archive/ubuntu/ppa/+build/15108504/+files/libpng12-0_1.2.54-1ubuntu1.1_amd64.deb'
+# LIBPNG12_PKG="$CACHE_DIR/libpng12.deb"
+# LIBPNG12_PATH="$TMP_PATH/libpng12"
+# LIBPNG12_BINARY="$LIBPNG12_PATH/usr/lib/x86_64-linux-gnu"
 
 echo -e "${CYAN} Downloading libpng from ${LIBPNG12_URL} ${WHITE}"
 curl -L $LIBPNG12_URL -o $LIBPNG12_PKG
 
 echo -e "${GREEN}-----> Unpacking Debian package${WHITE}"
 dpkg -x $WKHTMLTOPDF_PKG $WKHTMLTOPDF_PATH
-dpkg -x $LIBPNG12_PKG $LIBPNG12_PATH
+# dpkg -x $LIBPNG12_PKG $LIBPNG12_PATH
 
 echo -e "${GREEN}-----> Setting permissions"
 chmod +x $WKHTMLTOPDF_BINARIES/*
 
 echo -e "${GREEN}-----> Moving binaries to the right place${WHITE}"
 mv $WKHTMLTOPDF_BINARIES/* $BIN_PATH/
-mv $LIBPNG12_BINARY/libpng12.so.0 $LIB_PATH/libpng12.so.0
+# mv $LIBPNG12_BINARY/libpng12.so.0 $LIB_PATH/libpng12.so.0
 
 echo -e "${GREEN}-----> Removing wkhtmltoimage binary${WHITE}"
 rm -rf "$BIN_PATH/wkhtmltoimage"
@@ -74,12 +74,13 @@ echo -e "${GREEN}-----> Setting Continer Start script in $BUILD_DIR/.profile.d${
 mkdir -p "$BUILD_DIR"/.profile.d
 cat <<EOF >"$BUILD_DIR"/.profile.d/wkhtmltopdf.sh
 export PATH="/app/.wkhtmltopdf/bin:\$PATH"
-export LD_LIBRARY_PATH="/app/.wkhtmltopdf/lib:\$LD_LIBRARY_PATH"
 EOF
+
+# export LD_LIBRARY_PATH="/app/.wkhtmltopdf/lib:\$LD_LIBRARY_PATH"
 
 echo -e "${GREEN}-----> Cleaning up${WHITE}"
 rm -rf $WKHTMLTOPDF_PATH
-rm -rf $LIBPNG12_PATH
+# rm -rf $LIBPNG12_PATH
 
 echo -e "${GREEN}-----> Installing fonts${WHITE}"
 mkdir -p $1/.fonts

--- a/bin/compile
+++ b/bin/compile
@@ -6,7 +6,6 @@ set -e
 WHITE="\e[97m"
 GREEN="\e[32m"
 YELLOW="\e[33m"
-CYAN="\e[36m"
 
 BUILD_DIR=$1
 CACHE_DIR=$2

--- a/bin/compile
+++ b/bin/compile
@@ -53,8 +53,8 @@ curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
 # LIBPNG12_PATH="$TMP_PATH/libpng12"
 # LIBPNG12_BINARY="$LIBPNG12_PATH/usr/lib/x86_64-linux-gnu"
 
-echo -e "${CYAN} Downloading libpng from ${LIBPNG12_URL} ${WHITE}"
-curl -L $LIBPNG12_URL -o $LIBPNG12_PKG
+# echo -e "${CYAN} Downloading libpng from ${LIBPNG12_URL} ${WHITE}"
+# curl -L $LIBPNG12_URL -o $LIBPNG12_PKG
 
 echo -e "${GREEN}-----> Unpacking Debian package${WHITE}"
 dpkg -x $WKHTMLTOPDF_PKG $WKHTMLTOPDF_PATH

--- a/bin/compile
+++ b/bin/compile
@@ -6,6 +6,7 @@ set -e
 WHITE="\e[97m"
 GREEN="\e[32m"
 YELLOW="\e[33m"
+CYAN="\e[36m"
 
 BUILD_DIR=$1
 CACHE_DIR=$2
@@ -43,14 +44,24 @@ else
   curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
 fi
 
+LIBPNG12_URL='https://launchpad.net/~ubuntu-security/+archive/ubuntu/ppa/+build/15108504/+files/libpng12-0_1.2.54-1ubuntu1.1_amd64.deb'
+LIBPNG12_PKG="$CACHE_DIR/libpng12.deb"
+LIBPNG12_PATH="$TMP_PATH/libpng12"
+LIBPNG12_BINARY="$LIBPNG12_PATH/usr/lib/x86_64-linux-gnu"
+
+echo -e "${CYAN} Downloading libpng from ${LIBPNG12_URL} ${WHITE}"
+curl -L $LIBPNG12_URL -o $LIBPNG12_PKG
+
 echo -e "${GREEN}-----> Unpacking Debian package${WHITE}"
 dpkg -x $WKHTMLTOPDF_PKG $WKHTMLTOPDF_PATH
+dpkg -x $LIBPNG12_PKG $LIBPNG12_PATH
 
 echo -e "${GREEN}-----> Setting permissions"
 chmod +x $WKHTMLTOPDF_BINARIES/*
 
 echo -e "${GREEN}-----> Moving binaries to the right place${WHITE}"
 mv $WKHTMLTOPDF_BINARIES/* $BIN_PATH/
+mv $LIBPNG12_BINARY/libpng12.so.0 $BIN_PATH/libpng12.so.0
 
 echo -e "${GREEN}-----> Removing wkhtmltoimage binary${WHITE}"
 rm -rf "$BIN_PATH/wkhtmltoimage"
@@ -63,6 +74,7 @@ EOF
 
 echo -e "${GREEN}-----> Cleaning up${WHITE}"
 rm -rf $WKHTMLTOPDF_PATH
+rm -rf $LIBPNG12_PATH
 
 echo -e "${GREEN}-----> Installing fonts${WHITE}"
 mkdir -p $1/.fonts

--- a/bin/compile
+++ b/bin/compile
@@ -12,9 +12,9 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 
 BIN_PATH="$BUILD_DIR/bin"
-LIB_PATH="$BUILD_DIR/lib"
+LIB_PATH="$BUILD_DIR/vendor/wkhtmltox/lib"
 TMP_PATH="$BUILD_DIR/tmp"
-mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
+mkdir -p $CACHE_DIR $BIN_PATH $LIB_PATH $TMP_PATH
 
 OS_VERSIONCODE=$(cat /etc/os-release | grep VERSION_CODENAME)
 

--- a/bin/compile
+++ b/bin/compile
@@ -12,6 +12,7 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 
 BIN_PATH="$BUILD_DIR/bin"
+LIB_PATH="$BUILD_DIR/lib"
 TMP_PATH="$BUILD_DIR/tmp"
 mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
 
@@ -61,7 +62,7 @@ chmod +x $WKHTMLTOPDF_BINARIES/*
 
 echo -e "${GREEN}-----> Moving binaries to the right place${WHITE}"
 mv $WKHTMLTOPDF_BINARIES/* $BIN_PATH/
-mv $LIBPNG12_BINARY/libpng12.so.0 $BIN_PATH/libpng12.so.0
+mv $LIBPNG12_BINARY/libpng12.so.0 $LIB_PATH/libpng12.so.0
 
 echo -e "${GREEN}-----> Removing wkhtmltoimage binary${WHITE}"
 rm -rf "$BIN_PATH/wkhtmltoimage"

--- a/bin/compile
+++ b/bin/compile
@@ -55,10 +55,10 @@ mv $WKHTMLTOPDF_BINARIES/* $BIN_PATH/
 echo "-----> Removing wkhtmltoimage binary"
 rm -rf "$BIN_PATH/wkhtmltoimage"
 
-echo $(pwd)
-echo $(ls)
-
-echo $(ls $BIN_PATH)
+mkdir -p "$BUILD_DIR"/.profile.d
+cat <<EOF >"$BUILD_DIR"/.profile.d/wkhtmltopdf.sh
+export PATH="/app/bin:\$PATH"
+EOF
 
 echo "-----> Cleaning up"
 rm -rf $WKHTMLTOPDF_PATH

--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 
 BIN_PATH="$BUILD_DIR/bin"
-LIB_PATH="$BUILD_DIR/vendor/wkhtmltox/lib"
+LIB_PATH="$BUILD_DIR/.heroku/vendor/lib"
 TMP_PATH="$BUILD_DIR/tmp"
 mkdir -p $CACHE_DIR $BIN_PATH $LIB_PATH $TMP_PATH
 

--- a/bin/compile
+++ b/bin/compile
@@ -70,7 +70,7 @@ rm -rf "$BIN_PATH/wkhtmltoimage"
 echo -e "${GREEN}-----> Setting Continer Start script in $BUILD_DIR/.profile.d${WHITE}"
 mkdir -p "$BUILD_DIR"/.profile.d
 cat <<EOF >"$BUILD_DIR"/.profile.d/wkhtmltopdf.sh
-export PATH="/app/bin:\$PATH"
+export PATH="/app/bin:/app/vendor/wkhtmltox/lib:\$PATH"
 EOF
 
 echo -e "${GREEN}-----> Cleaning up${WHITE}"

--- a/bin/compile
+++ b/bin/compile
@@ -43,9 +43,6 @@ else
   curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
 fi
 
-echo -e "${GREEN}-----> Downloading wkhtmltopdf Debian package from ${WKHTMLTOPDF_URL} ${WHITE}"
-curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
-
 echo -e "${GREEN}-----> Unpacking Debian package${WHITE}"
 dpkg -x $WKHTMLTOPDF_PKG $WKHTMLTOPDF_PATH
 

--- a/bin/compile
+++ b/bin/compile
@@ -12,9 +12,8 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 
 BIN_PATH="$BUILD_DIR/.wkhtmltopdf/bin"
-# LIB_PATH="$BUILD_DIR/.wkhtmltopdf/lib"
 TMP_PATH="$BUILD_DIR/tmp"
-mkdir -p $CACHE_DIR $BIN_PATH $LIB_PATH $TMP_PATH
+mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
 
 OS_VERSIONCODE=$(cat /etc/os-release | grep VERSION_CODENAME)
 
@@ -31,41 +30,31 @@ else
 fi
 
 WKHTMLTOPDF_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.${UBUNTU_VERSION}_amd64.deb"
-WKHTMLTOPDF_PKG="$CACHE_DIR/wkhtmltopdf.deb"
+WKHTMLTOPDF_PKG="$CACHE_DIR/wkhtmltopdf-${OS_VERSIONCODE}.deb"
 WKHTMLTOPDF_PATH="$TMP_PATH/wkhtmltopdf"
 WKHTMLTOPDF_BINARIES="$WKHTMLTOPDF_PATH/usr/local/bin"
 
 BIN_DIR=$(cd $(dirname $0); pwd)
 FONTS_DIR=$(cd "$BIN_DIR/../fonts"; pwd)
 
-# if [ -f $WKHTMLTOPDF_PKG ]; then
-#   echo -e "${GREEN}-----> Using wkhtmltopdf Debian package from cache${WHITE}"
-# else
-#   echo -e "${GREEN}-----> Downloading wkhtmltopdf Debian package from ${WKHTMLTOPDF_URL} ${WHITE}"
-#   curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
-# fi
+if [ -f $WKHTMLTOPDF_PKG ]; then
+  echo -e "${GREEN}-----> Using wkhtmltopdf Debian package from cache (${WKHTMLTOPDF_PKG}) ${WHITE}"
+else
+  echo -e "${GREEN}-----> Downloading wkhtmltopdf Debian package from ${WKHTMLTOPDF_URL} ${WHITE}"
+  curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
+fi
 
 echo -e "${GREEN}-----> Downloading wkhtmltopdf Debian package from ${WKHTMLTOPDF_URL} ${WHITE}"
 curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
 
-# LIBPNG12_URL='https://launchpad.net/~ubuntu-security/+archive/ubuntu/ppa/+build/15108504/+files/libpng12-0_1.2.54-1ubuntu1.1_amd64.deb'
-# LIBPNG12_PKG="$CACHE_DIR/libpng12.deb"
-# LIBPNG12_PATH="$TMP_PATH/libpng12"
-# LIBPNG12_BINARY="$LIBPNG12_PATH/usr/lib/x86_64-linux-gnu"
-
-# echo -e "${CYAN} Downloading libpng from ${LIBPNG12_URL} ${WHITE}"
-# curl -L $LIBPNG12_URL -o $LIBPNG12_PKG
-
 echo -e "${GREEN}-----> Unpacking Debian package${WHITE}"
 dpkg -x $WKHTMLTOPDF_PKG $WKHTMLTOPDF_PATH
-# dpkg -x $LIBPNG12_PKG $LIBPNG12_PATH
 
 echo -e "${GREEN}-----> Setting permissions"
 chmod +x $WKHTMLTOPDF_BINARIES/*
 
 echo -e "${GREEN}-----> Moving binaries to the right place${WHITE}"
 mv $WKHTMLTOPDF_BINARIES/* $BIN_PATH/
-# mv $LIBPNG12_BINARY/libpng12.so.0 $LIB_PATH/libpng12.so.0
 
 echo -e "${GREEN}-----> Removing wkhtmltoimage binary${WHITE}"
 rm -rf "$BIN_PATH/wkhtmltoimage"
@@ -76,11 +65,8 @@ cat <<EOF >"$BUILD_DIR"/.profile.d/wkhtmltopdf.sh
 export PATH="/app/.wkhtmltopdf/bin:\$PATH"
 EOF
 
-# export LD_LIBRARY_PATH="/app/.wkhtmltopdf/lib:\$LD_LIBRARY_PATH"
-
 echo -e "${GREEN}-----> Cleaning up${WHITE}"
 rm -rf $WKHTMLTOPDF_PATH
-# rm -rf $LIBPNG12_PATH
 
 echo -e "${GREEN}-----> Installing fonts${WHITE}"
 mkdir -p $1/.fonts

--- a/bin/compile
+++ b/bin/compile
@@ -70,7 +70,8 @@ rm -rf "$BIN_PATH/wkhtmltoimage"
 echo -e "${GREEN}-----> Setting Continer Start script in $BUILD_DIR/.profile.d${WHITE}"
 mkdir -p "$BUILD_DIR"/.profile.d
 cat <<EOF >"$BUILD_DIR"/.profile.d/wkhtmltopdf.sh
-export PATH="/app/bin:/app/vendor/wkhtmltox/lib:\$PATH"
+export PATH="/app/bin:\$PATH"
+export LD_LIBRARY_PATH="/app/vendor/wkhtmltox/lib:\$LD_LIBRARY_PATH"
 EOF
 
 echo -e "${GREEN}-----> Cleaning up${WHITE}"

--- a/bin/compile
+++ b/bin/compile
@@ -11,8 +11,8 @@ CYAN="\e[36m"
 BUILD_DIR=$1
 CACHE_DIR=$2
 
-BIN_PATH="$BUILD_DIR/bin"
-LIB_PATH="$BUILD_DIR/.heroku/vendor/lib"
+BIN_PATH="$BUILD_DIR/.wkhtmltopdf/bin"
+LIB_PATH="$BUILD_DIR/.wkhtmltopdf/lib"
 TMP_PATH="$BUILD_DIR/tmp"
 mkdir -p $CACHE_DIR $BIN_PATH $LIB_PATH $TMP_PATH
 
@@ -73,8 +73,8 @@ rm -rf "$BIN_PATH/wkhtmltoimage"
 echo -e "${GREEN}-----> Setting Continer Start script in $BUILD_DIR/.profile.d${WHITE}"
 mkdir -p "$BUILD_DIR"/.profile.d
 cat <<EOF >"$BUILD_DIR"/.profile.d/wkhtmltopdf.sh
-export PATH="/app/bin:\$PATH"
-export LD_LIBRARY_PATH="/app/vendor/wkhtmltox/lib:\$LD_LIBRARY_PATH"
+export PATH="/app/.wkhtmltopdf/bin:\$PATH"
+export LD_LIBRARY_PATH="/app/.wkhtmltopdf/lib:\$LD_LIBRARY_PATH"
 EOF
 
 echo -e "${GREEN}-----> Cleaning up${WHITE}"

--- a/bin/compile
+++ b/bin/compile
@@ -38,12 +38,15 @@ WKHTMLTOPDF_BINARIES="$WKHTMLTOPDF_PATH/usr/local/bin"
 BIN_DIR=$(cd $(dirname $0); pwd)
 FONTS_DIR=$(cd "$BIN_DIR/../fonts"; pwd)
 
-if [ -f $WKHTMLTOPDF_PKG ]; then
-  echo -e "${GREEN}-----> Using wkhtmltopdf Debian package from cache${WHITE}"
-else
-  echo -e "${GREEN}-----> Downloading wkhtmltopdf Debian package from ${WKHTMLTOPDF_URL} ${WHITE}"
-  curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
-fi
+# if [ -f $WKHTMLTOPDF_PKG ]; then
+#   echo -e "${GREEN}-----> Using wkhtmltopdf Debian package from cache${WHITE}"
+# else
+#   echo -e "${GREEN}-----> Downloading wkhtmltopdf Debian package from ${WKHTMLTOPDF_URL} ${WHITE}"
+#   curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
+# fi
+
+echo -e "${GREEN}-----> Downloading wkhtmltopdf Debian package from ${WKHTMLTOPDF_URL} ${WHITE}"
+curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
 
 LIBPNG12_URL='https://launchpad.net/~ubuntu-security/+archive/ubuntu/ppa/+build/15108504/+files/libpng12-0_1.2.54-1ubuntu1.1_amd64.deb'
 LIBPNG12_PKG="$CACHE_DIR/libpng12.deb"

--- a/bin/compile
+++ b/bin/compile
@@ -7,11 +7,6 @@ WHITE="\e[97m"
 GREEN="\e[32m"
 YELLOW="\e[33m"
 
-#!/usr/bin/env bash
-# bin/compile <build-dir> <cache-dir>
-
-set -e
-
 BUILD_DIR=$1
 CACHE_DIR=$2
 

--- a/bin/compile
+++ b/bin/compile
@@ -7,6 +7,11 @@ WHITE="\e[97m"
 GREEN="\e[32m"
 YELLOW="\e[33m"
 
+#!/usr/bin/env bash
+# bin/compile <build-dir> <cache-dir>
+
+set -e
+
 BUILD_DIR=$1
 CACHE_DIR=$2
 
@@ -14,46 +19,52 @@ BIN_PATH="$BUILD_DIR/bin"
 TMP_PATH="$BUILD_DIR/tmp"
 mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
 
-[ -z "$WKHTMLTOPDF_VERSION" ] && WKHTMLTOPDF_VERSION="0.12.4"
+
+if [ "$STACK" == "cedar-14" ]; then
+  UBUNTU_VERSION="trusty"
+elif [ "$STACK" == "heroku-16" ]; then
+  UBUNTU_VERSION="xenial"
+else
+  UBUNTU_VERSION="bionic"
+fi
+
+WKHTMLTOPDF_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.${UBUNTU_VERSION}_amd64.deb"
+WKHTMLTOPDF_PKG="$CACHE_DIR/wkhtmltopdf.deb"
+WKHTMLTOPDF_PATH="$TMP_PATH/wkhtmltopdf"
+WKHTMLTOPDF_BINARIES="$WKHTMLTOPDF_PATH/usr/local/bin"
 
 BIN_DIR=$(cd $(dirname $0); pwd)
 FONTS_DIR=$(cd "$BIN_DIR/../fonts"; pwd)
 
-echo -e "${GREEN}-----> OS${WHITE}"
-echo $OSTYPE
-echo $(cat /etc/os-release | grep VERSION_CODENAME)
-
-OS_VERSIONCODE=$(cat /etc/os-release | grep VERSION_CODENAME)
-
-if [[ "$OS_VERSIONCODE" == *"VERSION_CODENAME=focal"* ]]; then
-    # focal is codename of ubuntu 20
-    WKHTMLTOPDF_DEB="wkhtmltox_0.12.5-1.focal_amd64.deb"
-elif [[ "$OS_VERSIONCODE" == *"VERSION_CODENAME=xenial"* ]]; then
-    # install wkhtmltopdf for ubuntu 16
-    WKHTMLTOPDF_DEB="wkhtmltox_0.12.5-1.xenial_amd64.deb"
+if [ -f $WKHTMLTOPDF_PKG ]; then
+  echo "-----> Using wkhtmltopdf Debian package from cache"
 else
-    # default version is for ubuntu 16
-    echo -e "${YELLOW}WARNING: ${OS_VERSIONCODE} not supported, install default wkhtmltopdf deb for Ubuntu 16${WHITE}"
-    WKHTMLTOPDF_DEB="wkhtmltox_0.12.5-1.xenial_amd64.deb"
+  echo "-----> Downloading wkhtmltopdf Debian package from ${WKHTMLTOPDF_URL}"
+  curl -L $WKHTMLTOPDF_URL -o $WKHTMLTOPDF_PKG
 fi
 
-WKHTMLTOPDF_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/${WKHTMLTOPDF_DEB}"
+echo "-----> Unpacking Debian package"
+dpkg -x $WKHTMLTOPDF_PKG $WKHTMLTOPDF_PATH
 
-echo -e "${GREEN}-----> Downloading wkhtmltopdf deb${WHITE}"
-wget $WKHTMLTOPDF_URL
+echo "-----> Setting permissions"
+chmod +x $WKHTMLTOPDF_BINARIES/*
 
-echo -e "${GREEN}-----> Install wkhtmltopdf${WHITE}"
-apt update
-yes | apt install xfonts-75dpi xfonts-base
-yes | dpkg -i ./$WKHTMLTOPDF_DEB
+echo "-----> Moving binaries to the right place"
+mv $WKHTMLTOPDF_BINARIES/* $BIN_PATH/
 
-echo -e "${GREEN}-----> Cleaning up${WHITE}"
-rm -rf $WKHTMLTOPDF_DEB
+echo "-----> Removing wkhtmltoimage binary"
+rm -rf "$BIN_PATH/wkhtmltoimage"
 
-echo -e "${GREEN}-----> Installing fonts${WHITE}"
+echo $(pwd)
+echo $(ls)
+
+echo $(ls $BIN_PATH)
+
+echo "-----> Cleaning up"
+rm -rf $WKHTMLTOPDF_PATH
+
+echo "-----> Installing fonts"
 mkdir -p $1/.fonts
 ls $FONTS_DIR
 cp $FONTS_DIR/* $1/.fonts/
-fc-cache -fv $1/.fonts
-
-exit 0
+fc-cache -f $1/.fonts

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -5,7 +5,7 @@
 testCompile() {
     ${BUILDPACK_HOME}/bin/compile ${BUILD_DIR} ${BUILD_DIR}  # this comand can see echo logs
 
-    ${BUILD_DIR}/bin/wkhtmltopdf http://google.com google.pdf
+    ${BUILD_DIR}/.wkhtmltopdf/bin/wkhtmltopdf http://google.com google.pdf
 
     assertEquals "google.pdf" "$(ls -a | grep google.pdf)"
 }

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -5,7 +5,7 @@
 testCompile() {
     ${BUILDPACK_HOME}/bin/compile ${BUILD_DIR} ${BUILD_DIR}  # this comand can see echo logs
 
-    wkhtmltopdf http://google.com google.pdf
+    ${BUILD_DIR}/bin/wkhtmltopdf http://google.com google.pdf
 
     assertEquals "google.pdf" "$(ls -a | grep google.pdf)"
 }


### PR DESCRIPTION


## 目的 

安裝  wkhtmltopdf binary ，並且設定 bin path

## 前一個 release 碰到的問題

我們不能直接在 buildpack 使用 apt 或 pdkg 安裝
會碰到 readonly 的資料夾
參考 python buildpack 和其他 wkhtmltopdf buildpack
也是安裝在自己生出來的地方，再透過環境變數與啟動腳本讓安裝的東西生效

[其他人的 wkhtmltopdf 0.12.5](https://github.com/notvad/wkhtmltopdf-buildpack/blob/master/bin/compile)
[Heroku python](https://github.com/heroku/heroku-buildpack-python/blob/main/bin/steps/python)


於是就照做

## 測試
<img width="1372" alt="CleanShot 2021-05-03 at 13 03 28@2x" src="https://user-images.githubusercontent.com/52438637/116842767-427eea00-ac10-11eb-9f0b-bef006e04471.png">
